### PR TITLE
Remove the "no-std" crate category

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ documentation = "https://docs.rs/bumpalo-herd"
 license = "MIT/Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/vorner/bumpalo-herd"
-categories = ["memory-management", "rust-patterns", "no-std"]
+categories = ["memory-management", "rust-patterns"]
 description = "Support for bumpalo in scoped threads & rayon"
 
 [dependencies]


### PR DESCRIPTION
`Herd` contains a `std::sync::Mutex`, so this is not a "no-std" crate.